### PR TITLE
fix: remove unused strict_mode and update README with PATH setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,39 @@ It is a governance layer.
 
 Install globally:
 
+```bash
 npm install -g @sdotwinter/openclaw-deterministic
+```
+
+Add to your PATH (optional but recommended):
+
+```bash
+export PATH="$PATH:$(npm root -g)/@sdotwinter/openclaw-deterministic/bin"
+```
+
+Or create a symlink:
+
+```bash
+sudo ln -s $(npm root -g)/@sdotwinter/openclaw-deterministic/bin/oc-deterministic /usr/local/bin/
+```
 
 Apply deterministic governance to an existing OpenClaw workspace:
 
+```bash
 oc-deterministic install
+```
 
 Verify installation:
 
+```bash
 oc-deterministic doctor
+```
 
 Concise health summary (CI-friendly):
 
+```bash
 oc-deterministic status
+```
 
 ---
 
@@ -156,12 +176,17 @@ Configuration file:
 
 Example:
 
+```json
 {
   "semantic": {
     "HARD_LIMIT": 1200,
     "RISK_THRESHOLD_PERCENT": 85
+  },
+  "governance": {
+    "violation_logging": true
   }
 }
+```
 
 This prevents uncontrolled memory expansion.
 

--- a/templates/config/.deterministic.json
+++ b/templates/config/.deterministic.json
@@ -4,7 +4,6 @@
     "RISK_THRESHOLD_PERCENT": 85
   },
   "governance": {
-    "strict_mode": false,
     "violation_logging": true
   }
 }


### PR DESCRIPTION
Summary:
- Remove unused  from config template
- Add PATH setup instructions to README
- Add code blocks for all CLI commands in README
- Update config example to match current template

Files changed:
- templates/config/.deterministic.json
- README.md

Risk level: Low (config cleanup + docs)

Migration impact: None - new installs won't see unused config key

Rollback plan: Revert commit